### PR TITLE
fix: AvailabilityZoneB and AvailabilityZoneC output values

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -234,12 +234,12 @@ Outputs:
     Export:
       Name: !Sub '${AWS::StackName}-AvailabilityZoneA'
   AvailabilityZoneB:
-    Value: !GetAtt 'SubnetAPublic.Outputs.AvailabilityZone'
+    Value: !GetAtt 'SubnetBPublic.Outputs.AvailabilityZone'
     Export:
       Name: !Sub '${AWS::StackName}-AvailabilityZoneB'
   AvailabilityZoneC:
     Condition: HasAvailabilityZoneC
-    Value: !GetAtt 'SubnetAPublic.Outputs.AvailabilityZone'
+    Value: !GetAtt 'SubnetCPublic.Outputs.AvailabilityZone'
     Export:
       Name: !Sub '${AWS::StackName}-AvailabilityZoneC'
   SubnetIdsPublic:


### PR DESCRIPTION
Outputs values for `AvailabilityZoneB` and `AvailabilityZoneC` are incorrect, they are stuck using `SubnetAPublic`:

![image](https://user-images.githubusercontent.com/1607385/56632630-b0a77400-6628-11e9-9847-2665a351626f.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
