### PR TITLE
Add support for single, shared NAT Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,10 @@ Once the stack is created, you can use the stack name (in this case `vpc`) as th
     </tr>
     <tr>
       <td>NatGateways</td>
-      <td>Add Nat Gateway per private Subnet?</td>
+      <td>Add Nat Gateway for pivate subnet(s) per public Subnet?</td>
       <td>true</td>
       <td>no</td>
-      <td>[true, false]</td>
+      <td>[true, false, single]</td>
     </tr>
   </tbody>
 </table>

--- a/module.yml
+++ b/module.yml
@@ -54,18 +54,22 @@ Parameters:
     Default: 14
     AllowedValues: [1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1827, 3653]
   NatGateways:
-    Description: 'Add Nat Gateway per private Subnet?'
+    Description: 'Add Nat Gateways? If so, how do want to configure NAT Gateway creation? The default is per public subnet. Having a NAT Gateway per public subnet is reccomended for HA. Single configuration saves money at the increased risk of a single point of failure.'
     Type: String
     Default: true
-    AllowedValues: [true, false]
+    AllowedValues: [true, false, 'single']
 Conditions:
   HasAvailabilityZoneC: !Equals [!Ref NumberOfAvailabilityZones, 3]
   HasS3Endpoint: !Equals [!Ref S3Endpoint, true]
   HasDynamoDBEndpoint: !Equals [!Ref DynamoDBEndpoint, true]
   HasFlowLog: !Not [!Equals [!Ref FlowLog, false]]
   HasFlowLogRejectOnly: !Equals [!Ref FlowLog, 'reject-only']
-  HasNatGateways: !Equals [!Ref NatGateways, true]
-  HasAvailabilityZoneCAndNatGateways: !And [!Condition HasAvailabilityZoneC, !Condition HasNatGateways]
+  HasNatGateways: !Or [!Equals [!Ref NatGateways, 'single'], !Equals [!Ref NatGateways, true]]
+  HasSingleNatGateway: !And [!Condition HasNatGateways, !Equals [!Ref NatGateways, 'single']]
+  HasMultiNatGateways: !And [!Condition HasNatGateways, !Equals [!Ref NatGateways, true]]
+  HasAvailabilityZoneAAndBAndSingleNatGateway: !And [!Not [!Condition HasAvailabilityZoneC], !Condition HasSingleNatGateway]
+  HasAvailabilityZoneABAndCAndSingleNatGateway: !And [!Condition HasAvailabilityZoneC, !Condition HasSingleNatGateway]
+  HasAvailabilityZoneCAndNatGateways: !And [!Condition HasAvailabilityZoneC, !Condition HasMultiNatGateways]
 Resources:
   VpcPlain:
     Type: 'AWS::CloudFormation::Stack'
@@ -95,13 +99,34 @@ Resources:
         SubnetIndex: '1'
         SubnetCount: !If [HasAvailabilityZoneC, 6, 4]
       TemplateURL: './node_modules/@cfn-modules/vpc-subnet/module.yml'
-  NatGatewayA:
-    Condition: HasNatGateways
+  NatGatewaySingleAB:
+    Condition: HasAvailabilityZoneAAndBAndSingleNatGateway
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       Parameters:
         PublicSubnetModule: !GetAtt 'SubnetAPublic.Outputs.StackName'
-        PrivateSubnetModule: !GetAtt 'SubnetAPrivate.Outputs.StackName'
+        PrivateSubnetModuleA: !GetAtt 'SubnetAPrivate.Outputs.StackName'
+        PrivateSubnetModuleB: !GetAtt 'SubnetBPrivate.Outputs.StackName'
+        AlertingModule: !Ref AlertingModule
+      TemplateURL: './node_modules/@cfn-modules/vpc-nat-gateway/module.yml'
+  NatGatewaySingleABC:
+    Condition: HasAvailabilityZoneABAndCAndSingleNatGateway
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      Parameters:
+        PublicSubnetModule: !GetAtt 'SubnetAPublic.Outputs.StackName'
+        PrivateSubnetModuleA: !GetAtt 'SubnetAPrivate.Outputs.StackName'
+        PrivateSubnetModuleB: !GetAtt 'SubnetBPrivate.Outputs.StackName'
+        PrivateSubnetModuleC: !GetAtt 'SubnetCPrivate.Outputs.StackName'
+        AlertingModule: !Ref AlertingModule
+      TemplateURL: './node_modules/@cfn-modules/vpc-nat-gateway/module.yml'
+  NatGatewayA:
+    Condition: HasMultiNatGateways
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      Parameters:
+        PublicSubnetModule: !GetAtt 'SubnetAPublic.Outputs.StackName'
+        PrivateSubnetModuleA: !GetAtt 'SubnetAPrivate.Outputs.StackName'
         AlertingModule: !Ref AlertingModule
       TemplateURL: './node_modules/@cfn-modules/vpc-nat-gateway/module.yml'
   SubnetBPublic:
@@ -127,12 +152,12 @@ Resources:
         SubnetCount: !If [HasAvailabilityZoneC, 6, 4]
       TemplateURL: './node_modules/@cfn-modules/vpc-subnet/module.yml'
   NatGatewayB:
-    Condition: HasNatGateways
+    Condition: HasMultiNatGateways
     Type: 'AWS::CloudFormation::Stack'
     Properties:
       Parameters:
         PublicSubnetModule: !GetAtt 'SubnetBPublic.Outputs.StackName'
-        PrivateSubnetModule: !GetAtt 'SubnetBPrivate.Outputs.StackName'
+        PrivateSubnetModuleB: !GetAtt 'SubnetBPrivate.Outputs.StackName'
         AlertingModule: !Ref AlertingModule
       TemplateURL: './node_modules/@cfn-modules/vpc-nat-gateway/module.yml'
   SubnetCPublic:
@@ -165,7 +190,7 @@ Resources:
     Properties:
       Parameters:
         PublicSubnetModule: !GetAtt 'SubnetCPublic.Outputs.StackName'
-        PrivateSubnetModule: !GetAtt 'SubnetCPrivate.Outputs.StackName'
+        PrivateSubnetModuleC: !GetAtt 'SubnetCPrivate.Outputs.StackName'
         AlertingModule: !Ref AlertingModule
       TemplateURL: './node_modules/@cfn-modules/vpc-nat-gateway/module.yml'
   VPCEndpointS3:


### PR DESCRIPTION
# What does this PR do?

This adds configuration to have only 1 NAT Gateway for a 2 or 3 AZ VPC. Since it is best practice to have 1 NAT Gateway per AZ, that is left as default. This configuration is meant as a cost savings option at the risk of a single point of failure. 