### PR TITLE
Readme export

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ aws cloudformation package --template-file ./node_modules/@cfn-modules/vpc/modul
 aws cloudformation deploy --template-file packaged.yml --stack-name vpc --capabilities CAPABILITY_IAM
 ```
 
-Once the stack is created, you can use the stack name (in this case `vpc`) as the value for the `VpcModule` parameter in other `cfn-modules`. If this template has been embedded in a parent template where the default have been overridden it is important to re-export the outputs of the stack so they can be used in oher stand-alone stacks:
+Once the stack is created, you can use the stack name (in this case `vpc`) as the value for the `VpcModule` parameter in other `cfn-modules`. If this template has been embedded in a parent template where the default have been overridden, it is important to re-export the outputs of the stack so they can be used in oher stand-alone stacks:
 
 ```
 StackName:

--- a/README.md
+++ b/README.md
@@ -61,7 +61,16 @@ aws cloudformation package --template-file ./node_modules/@cfn-modules/vpc/modul
 aws cloudformation deploy --template-file packaged.yml --stack-name vpc --capabilities CAPABILITY_IAM
 ```
 
-Once the stack is created, you can use the stack name (in this case `vpc`) as the value for the `VpcModule` parameter in other `cfn-modules`.
+Once the stack is created, you can use the stack name (in this case `vpc`) as the value for the `VpcModule` parameter in other `cfn-modules`. If this template has been embedded in a parent template where the default have been overridden it is important to re-export the outputs of the stack so they can be used in oher stand-alone stacks:
+
+```
+StackName:
+    Value: !GetAtt Vpc.Outputs.StackName
+    Export:
+      Name: !Sub '${AWS::StackName}'
+```
+
+This will mean you can refer to the `VpcModule` in other configurations.
 
 ## Parameters
 


### PR DESCRIPTION
I think to the new user to cloud formation is is tricky to understand that
if I use vpc module in a parent file, but want to refer to the Vpc Module from
a separate stack in another template the outputs of the vpc module need to be exported.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
